### PR TITLE
[CCM-7883]: Filtering recommended Vms based on request parameters (minCpu and minMem)

### DIFF
--- a/pkg/recommender/engine.go
+++ b/pkg/recommender/engine.go
@@ -260,6 +260,9 @@ func (e *Engine) getCheapestNodePoolSet(provider string, req SingleClusterRecomm
 			return nil, emperror.WrapWith(err, "failed to recommend virtual machines", RecommenderErrorTag)
 		}
 
+		// Filtering recommended Vms based on request parameters (minCpu and minMem)
+		odVms, spotVms = e.vmSelector.FilterVmsBasedOnReqParams(attr, req, odVms, spotVms)
+
 		if (len(odVms) == 0 && req.OnDemandPct > 0) || (len(spotVms) == 0 && req.OnDemandPct < 100) {
 			e.log.Debug("no vms with the requested resources found", map[string]interface{}{"attribute": attr})
 			// skip the nodepool creation, go to the next attr

--- a/pkg/recommender/engine_test.go
+++ b/pkg/recommender/engine_test.go
@@ -105,6 +105,10 @@ func (v *dummyVms) FindVmsWithAttrValues(attr string, req SingleClusterRecommend
 	return nil, nil
 }
 
+func (v *dummyVms) FilterVmsBasedOnReqParams(attr string, req SingleClusterRecommendationReq, odVms []VirtualMachine, spotVms []VirtualMachine) ([]VirtualMachine, []VirtualMachine) {
+	return nil, nil
+}
+
 type dummyNodePools struct {
 	// test case id to drive the behaviour
 	TcId string

--- a/pkg/recommender/types.go
+++ b/pkg/recommender/types.go
@@ -51,6 +51,8 @@ type VmRecommender interface {
 	RecommendVms(provider string, vms []VirtualMachine, attr string, req SingleClusterRecommendationReq, layout []NodePool) ([]VirtualMachine, []VirtualMachine, error)
 
 	FindVmsWithAttrValues(attr string, req SingleClusterRecommendationReq, layoutDesc []NodePoolDesc, allProducts []VirtualMachine) ([]VirtualMachine, error)
+
+	FilterVmsBasedOnReqParams(attr string, req SingleClusterRecommendationReq, odVms []VirtualMachine, spotVms []VirtualMachine) ([]VirtualMachine, []VirtualMachine)
 }
 
 type NodePoolRecommender interface {

--- a/pkg/recommender/vms/recommender.go
+++ b/pkg/recommender/vms/recommender.go
@@ -136,6 +136,40 @@ func (s *vmSelector) FindVmsWithAttrValues(attr string,
 	return vms, nil
 }
 
+func (s *vmSelector) FilterVmsBasedOnReqParams(attr string, req recommender.SingleClusterRecommendationReq, odVms []recommender.VirtualMachine, spotVms []recommender.VirtualMachine) ([]recommender.VirtualMachine, []recommender.VirtualMachine) {
+	var filteredOdVms, filteredSpotVms []recommender.VirtualMachine = odVms, spotVms
+	if attr == recommender.Cpu {
+		if req.MinMem != nil {
+			filteredOdVms, filteredSpotVms = s.FilterVmsBasedOnMinMemory(req, odVms), s.FilterVmsBasedOnMinMemory(req, spotVms)
+		}
+	} else if attr == recommender.Memory {
+		if req.MinCpu != nil {
+			filteredOdVms, filteredSpotVms = s.FilterVmsBasedOnMinCpu(req, odVms), s.FilterVmsBasedOnMinCpu(req, spotVms)
+		}
+	}
+	return filteredOdVms, filteredSpotVms
+}
+
+func (s *vmSelector) FilterVmsBasedOnMinMemory(req recommender.SingleClusterRecommendationReq, vms []recommender.VirtualMachine) ([]recommender.VirtualMachine) {
+	var filteredVms []recommender.VirtualMachine
+	for _, vm := range vms {
+		if vm.AllocatableMem >= *req.MinMem {
+			filteredVms = append(filteredVms, vm)
+		}
+	}
+	return filteredVms
+}
+
+func (s *vmSelector) FilterVmsBasedOnMinCpu(req recommender.SingleClusterRecommendationReq, vms []recommender.VirtualMachine) ([]recommender.VirtualMachine) {
+	var filteredVms []recommender.VirtualMachine
+	for _, vm := range vms {
+		if vm.AllocatableCpus >= *req.MinCpu {
+			filteredVms = append(filteredVms, vm)
+		}
+	}
+	return filteredVms
+}
+
 // recommendAttrValues selects the attribute values allowed to participate in the recommendation process
 func (s *vmSelector) recommendAttrValues(allProducts []recommender.VirtualMachine, attr string, req recommender.SingleClusterRecommendationReq) ([]float64, error) {
 


### PR DESCRIPTION
Filtering recommended Vms based on request parameters (minCpu and minMem). This is to handle the minWorkload for both CPU and Memory.

Right now, we are recommending VM either from CPU node pool set or from Memory node pool set. Hence, if user is passing minCpu as 16 and minMem as 60, we are recommending CPU VM with allocatableCpu as 16 and allocatableMem as 32 which is incorrect.

Now, we are doing AND to handle this scenario. In case of CPU node pool set, we are filtering VMs based on the minMem and vice-versa for Memory node pool set.