### PR TITLE
[fix]:[CCM-10253]: Changed builder base image from Alpine Linux Distribution to Debian Buster Distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 # build stage
-FROM golang:1.16-alpine3.13 AS builder
+FROM golang:1.19.2-buster AS builder
 ENV GOFLAGS="-mod=readonly"
 
-RUN apk add --update --no-cache ca-certificates make git curl mercurial
+RUN apt-get update && apt-get install -y ca-certificates make git curl mercurial
+#RUN apk add --update --no-cache ca-certificates make git curl mercurial
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/main-targets.mk
+++ b/main-targets.mk
@@ -20,7 +20,7 @@ endif
 ifneq (${IGNORE_GOLANG_VERSION_REQ}, 1)
 	@printf "${GOLANG_VERSION}\n$$(go version | awk '{sub(/^go/, "", $$3);print $$3}')" | sort -t '.' -k 1,1 -k 2,2 -k 3,3 -g | head -1 | grep -q -E "^${GOLANG_VERSION}$$" || (printf "Required Go version is ${GOLANG_VERSION}\nInstalled: `go version`" && exit 1)
 endif
-	go build ${GOARGS} -tags "${GOTAGS}" -ldflags "${LDFLAGS}" -o ${BUILD_DIR}/${BINARY_NAME} ${BUILD_PACKAGE}
+	go build -buildvcs=false ${GOARGS} -tags "${GOTAGS}" -ldflags "${LDFLAGS}" -o ${BUILD_DIR}/${BINARY_NAME} ${BUILD_PACKAGE}
 
 .PHONY: build-release
 build-release: ## Build a binary without debug information


### PR DESCRIPTION
We have switched to using the Debian "Buster" distribution for the builder phase due to security vulnerabilities in the Alpine Linux distribution base OS.

**Existing**: `FROM golang:1.16-alpine3.13 AS builder`

**Now**: `FROM golang:1.19.2-buster AS builder`
