### PR TITLE
[fix]:[CCM-10253]: Changed base image from public Debian Buster Distribution to harness UBI distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
 USER root
-RUN microdnf update && microdnf install -y ca-certificates make git curl mercurial && microdnf clean all
+RUN microdnf update && microdnf install -y ca-certificates make git curl python3-pip && microdnf clean all
+RUN pip3 install mercurial
 USER default
 
 RUN mkdir -p /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
 USER root
-RUN microdnf update && microdnf install -y ca-certificates make git curl python3-pip python3-devel && microdnf clean all
-RUN pip3 install mercurial
+RUN microdnf update && microdnf install -y ca-certificates make git curl && microdnf clean all
 USER default
 
 RUN mkdir -p /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ ENV GOFLAGS="-mod=readonly"
 
 USER root
 RUN microdnf update && microdnf install -y ca-certificates make git curl && microdnf clean all
-USER default
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,30 @@
 # build stage
-FROM golang:1.19.2-buster AS builder
+#FROM golang:1.19.2-buster AS builder
+#ENV GOFLAGS="-mod=readonly"
+#
+#RUN apt-get update && apt-get install -y ca-certificates make git curl mercurial
+#
+#RUN mkdir -p /build
+#WORKDIR /build
+#
+#COPY go.* /build/
+#RUN go mod download
+#
+#COPY . /build
+#RUN BINARY_NAME=telescopes make build-release
+#
+#FROM us.gcr.io/platform-205701/ubi/ubi-go:latest
+#USER root
+#
+#COPY --from=builder /build/build/release/telescopes /bin
+#
+#ENTRYPOINT ["/bin/telescopes"]
+#CMD ["/bin/telescopes"]
+#
+FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
 RUN apt-get update && apt-get install -y ca-certificates make git curl mercurial
-#RUN apk add --update --no-cache ca-certificates make git curl mercurial
 
 RUN mkdir -p /build
 WORKDIR /build
@@ -14,17 +35,10 @@ RUN go mod download
 COPY . /build
 RUN BINARY_NAME=telescopes make build-release
 
-# FROM alpine:3.14.0
-# FROM us.gcr.io/platform-205701/ubi/ubi-base:latest
-#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
 FROM us.gcr.io/platform-205701/ubi/ubi-go:latest
 USER root
-# RUN microdnf install yum
-# RUN apk add --update --no-cache ca-certificates tzdata bash curl
-# RUN yum install -y ca-certificates tzdata
 
 COPY --from=builder /build/build/release/telescopes /bin
 
 ENTRYPOINT ["/bin/telescopes"]
 CMD ["/bin/telescopes"]
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
-RUN yum update -y && yum install -y ca-certificates make git curl mercurial
+RUN microdnf update && microdnf install -y ca-certificates make git curl mercurial && microdnf clean all
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
 USER root
-RUN microdnf update && microdnf install -y ca-certificates make git curl python3-pip && microdnf clean all
+RUN microdnf update && microdnf install -y ca-certificates make git curl python3-pip python3-devel && microdnf clean all
 RUN pip3 install mercurial
 USER default
 
@@ -45,4 +45,5 @@ COPY --from=builder /build/build/release/telescopes /bin
 
 ENTRYPOINT ["/bin/telescopes"]
 CMD ["/bin/telescopes"]
+
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
-RUN apt-get update && apt-get install -y ca-certificates make git curl mercurial
+RUN yum update -y && yum install -y ca-certificates make git curl mercurial
 
 RUN mkdir -p /build
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,9 @@
 FROM us.gcr.io/platform-205701/ubi/ubi-go:latest AS builder
 ENV GOFLAGS="-mod=readonly"
 
+USER root
 RUN microdnf update && microdnf install -y ca-certificates make git curl mercurial && microdnf clean all
+USER default
 
 RUN mkdir -p /build
 WORKDIR /build
@@ -42,3 +44,4 @@ COPY --from=builder /build/build/release/telescopes /bin
 
 ENTRYPOINT ["/bin/telescopes"]
 CMD ["/bin/telescopes"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ COPY . /build
 RUN BINARY_NAME=telescopes make build-release
 
 # FROM alpine:3.14.0
-# FROM us.gcr.io/platform-205701/ubi/ubi-go:latest
 # FROM us.gcr.io/platform-205701/ubi/ubi-base:latest
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
+#FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854
+FROM us.gcr.io/platform-205701/ubi/ubi-go:latest
 USER root
 # RUN microdnf install yum
 # RUN apk add --update --no-cache ca-certificates tzdata bash curl


### PR DESCRIPTION
We have switched to using harness ubi image from redhat ubi image version.

Existing: `FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6-854`

Now: `FROM us.gcr.io/platform-205701/ubi/ubi-go:latest`